### PR TITLE
chore: Enable CSRF protection in dummy app

### DIFF
--- a/rails_cron/spec/dummy/app/controllers/application_controller.rb
+++ b/rails_cron/spec/dummy/app/controllers/application_controller.rb
@@ -4,4 +4,5 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Adds `protect_from_forgery` to the ApplicationController. This is a standard security measure in Rails to prevent cross-site request forgery attacks and makes the test application more realistic.
