### PR TITLE
feat: add Rake tasks for RailsCron management

### DIFF
--- a/docs/pages/5-usage.md
+++ b/docs/pages/5-usage.md
@@ -40,6 +40,8 @@ RailsCron.register(
 
 ## 🕒 Starting the Scheduler
 
+`RailsCron` does **not** auto-start by default. Start it explicitly via `RailsCron.start!` or `rails_cron:start`.
+
 You can start the scheduler loop in one of two ways:
 
 ### Option 1 — Inline in Rails

--- a/rails_cron/README.md
+++ b/rails_cron/README.md
@@ -90,6 +90,8 @@ RailsCron.register(
 
 Start the scheduler:
 
+`RailsCron` does **not** auto-start by default. Start it explicitly via `RailsCron.start!` or `rails_cron:start`.
+
 ```bash
 bundle exec rails rails_cron:start
 ```

--- a/rails_cron/lib/rails_cron.rb
+++ b/rails_cron/lib/rails_cron.rb
@@ -21,6 +21,7 @@ require 'rails_cron/lock/sqlite_adapter'
 require 'rails_cron/idempotency_key_generator'
 require 'rails_cron/cron_utils'
 require 'rails_cron/cron_humanizer'
+require 'rails_cron/rake_tasks'
 require 'rails_cron/coordinator'
 require 'rails_cron/railtie'
 

--- a/rails_cron/lib/rails_cron/railtie.rb
+++ b/rails_cron/lib/rails_cron/railtie.rb
@@ -91,6 +91,12 @@ module RailsCron
     end
 
     ##
+    # Load rake tasks into host Rails applications.
+    rake_tasks do
+      load File.expand_path('../tasks/rails_crons_tasks.rake', __dir__)
+    end
+
+    ##
     # Load the default initializer after Rails has finished initialization.
     # This ensures Rails.logger is fully available and sets up signal handlers.
     config.after_initialize do

--- a/rails_cron/lib/rails_cron/rake_tasks.rb
+++ b/rails_cron/lib/rails_cron/rake_tasks.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'rake'
+
+module RailsCron
+  ##
+  # Defines RailsCron rake tasks on a given Rake application.
+  module RakeTasks
+    module_function
+
+    def install(rake_application = Rake.application)
+      rake_application.extend(Rake::DSL)
+
+      rake_application.instance_eval do
+        namespace :rails_cron do
+          RailsCron::RakeTasks.define_tick_task(self)
+          RailsCron::RakeTasks.define_status_task(self)
+          RailsCron::RakeTasks.define_explain_task(self)
+          RailsCron::RakeTasks.define_start_task(self)
+        end
+      end
+    end
+
+    def define_tick_task(context)
+      context.instance_eval do
+        desc 'Perform a single scheduler tick'
+        task tick: :environment do
+          RailsCron.tick!
+          puts 'RailsCron tick completed'
+        rescue StandardError => e
+          abort("rails_cron:tick failed: #{e.message}")
+        end
+      end
+    end
+
+    def define_status_task(context)
+      context.instance_eval do
+        desc 'Show scheduler status, configuration, and registered cron jobs'
+        task status: :environment do
+          puts "RailsCron v#{RailsCron::VERSION}"
+          puts "Running: #{RailsCron.running?}"
+          puts "Tick interval: #{RailsCron.tick_interval}s"
+          puts "Window lookback: #{RailsCron.window_lookback}s"
+          puts "Window lookahead: #{RailsCron.window_lookahead}s"
+          puts "Lease TTL: #{RailsCron.lease_ttl}s"
+          puts "Namespace: #{RailsCron.namespace}"
+
+          entries = RailsCron.registered
+          puts "Registered jobs: #{entries.length}"
+          entries.each do |entry|
+            puts "  - #{entry.key} (#{entry.cron})"
+          end
+        rescue StandardError => e
+          abort("rails_cron:status failed: #{e.message}")
+        end
+      end
+    end
+
+    def define_explain_task(context)
+      context.instance_eval do
+        desc 'Humanize a cron expression, e.g. rake rails_cron:explain["*/5 * * * *"]'
+        task :explain, [:expr] => :environment do |_task, args|
+          expression = args[:expr].to_s.strip
+          abort('rails_cron:explain requires expr argument') if expression.empty?
+
+          puts RailsCron.to_human(expression)
+        rescue StandardError => e
+          abort("rails_cron:explain failed: #{e.message}")
+        end
+      end
+    end
+
+    def define_start_task(context)
+      context.instance_eval do
+        desc 'Start scheduler loop in foreground (blocks until stopped)'
+        task start: :environment do
+          thread = RailsCron.start!
+          abort('rails_cron:start failed: scheduler is already running') unless thread
+
+          puts 'RailsCron scheduler started in foreground'
+          thread.join
+        rescue Interrupt
+          RailsCron.stop!(timeout: 30)
+          puts 'RailsCron scheduler stopped'
+        rescue StandardError => e
+          abort("rails_cron:start failed: #{e.message}")
+        end
+      end
+    end
+  end
+end

--- a/rails_cron/lib/tasks/rails_crons_tasks.rake
+++ b/rails_cron/lib/tasks/rails_crons_tasks.rake
@@ -5,7 +5,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# desc "Explaining what the task does"
-# task :rails_cron do
-#   # Task goes here
-# end
+require 'rails_cron/rake_tasks'
+
+RailsCron::RakeTasks.install

--- a/rails_cron/spec/rails_cron/railtie_spec.rb
+++ b/rails_cron/spec/rails_cron/railtie_spec.rb
@@ -348,6 +348,20 @@ RSpec.describe RailsCron::Railtie do
     it 'responds to register_signal_handlers' do
       expect(described_class).to respond_to(:register_signal_handlers)
     end
+
+    it 'registers rake task loader for rails_cron tasks' do
+      original_rake = Rake.application
+      Rake.application = Rake::Application.new
+
+      Rails.application.load_tasks
+
+      expect(Rake::Task.task_defined?('rails_cron:tick')).to be(true)
+      expect(Rake::Task.task_defined?('rails_cron:status')).to be(true)
+      expect(Rake::Task.task_defined?('rails_cron:explain')).to be(true)
+      expect(Rake::Task.task_defined?('rails_cron:start')).to be(true)
+    ensure
+      Rake.application = original_rake
+    end
   end
 
   describe '.handle_shutdown' do

--- a/rails_cron/spec/rails_cron/rake_tasks_spec.rb
+++ b/rails_cron/spec/rails_cron/rake_tasks_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require 'spec_helper'
+require 'rake'
+require 'stringio'
+
+RSpec.describe RailsCron::RakeTasks do
+  let(:rake) { Rake::Application.new }
+
+  before do
+    Rake.application = rake
+    rake.define_task(Rake::Task, :environment)
+    described_class.install(rake)
+  end
+
+  after do
+    Rake.application = nil
+  end
+
+  def task(name)
+    rake[name]
+  end
+
+  describe 'rails_cron:tick' do
+    it 'runs a single tick and prints success' do
+      allow(RailsCron).to receive(:tick!)
+
+      expect { task('rails_cron:tick').invoke }.to output(/tick completed/).to_stdout
+      expect(RailsCron).to have_received(:tick!)
+    end
+
+    it 'aborts on errors' do
+      allow(RailsCron).to receive(:tick!).and_raise(StandardError, 'boom')
+
+      expect { task('rails_cron:tick').invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  describe 'rails_cron:status' do
+    it 'prints scheduler state and registered jobs' do
+      entry = instance_double(RailsCron::Registry::Entry, key: 'reports:daily', cron: '0 9 * * *')
+      allow(RailsCron).to receive_messages(
+        running?: false,
+        tick_interval: 5,
+        window_lookback: 120,
+        window_lookahead: 0,
+        lease_ttl: 125,
+        namespace: 'railscron',
+        registered: [entry]
+      )
+
+      output = capture_stdout { task('rails_cron:status').invoke }
+      expect(output).to include('RailsCron v')
+      expect(output).to include('Running: false')
+      expect(output).to include('Registered jobs: 1')
+      expect(output).to include('reports:daily')
+    end
+
+    it 'aborts on errors' do
+      allow(RailsCron).to receive(:running?).and_raise(StandardError, 'boom')
+
+      expect { task('rails_cron:status').invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  describe 'rails_cron:explain' do
+    it 'prints humanized cron text' do
+      allow(RailsCron).to receive(:to_human).with('*/5 * * * *').and_return('Every 5 minutes')
+
+      expect { task('rails_cron:explain').invoke('*/5 * * * *') }.to output("Every 5 minutes\n").to_stdout
+    end
+
+    it 'aborts when expression argument is missing' do
+      expect { task('rails_cron:explain').invoke }.to raise_error(SystemExit)
+    end
+
+    it 'aborts with invalid cron expressions' do
+      allow(RailsCron).to receive(:to_human).and_raise(ArgumentError, 'Invalid cron expression')
+
+      expect { task('rails_cron:explain').invoke('bad') }.to raise_error(SystemExit)
+    end
+  end
+
+  describe 'rails_cron:start' do
+    it 'starts scheduler in foreground and joins thread' do
+      thread = instance_double(Thread, join: nil)
+      allow(RailsCron).to receive(:start!).and_return(thread)
+
+      expect { task('rails_cron:start').invoke }.to output(/started in foreground/).to_stdout
+      expect(thread).to have_received(:join)
+    end
+
+    it 'aborts when scheduler is already running' do
+      allow(RailsCron).to receive(:start!).and_return(nil)
+
+      expect { task('rails_cron:start').invoke }.to raise_error(SystemExit)
+    end
+
+    it 'handles interrupts by stopping scheduler' do
+      thread = instance_double(Thread)
+      allow(thread).to receive(:join).and_raise(Interrupt)
+      allow(RailsCron).to receive(:start!).and_return(thread)
+      allow(RailsCron).to receive(:stop!).with(timeout: 30)
+
+      expect { task('rails_cron:start').invoke }.to output(/scheduler stopped/).to_stdout
+      expect(RailsCron).to have_received(:stop!).with(timeout: 30)
+    end
+
+    it 'aborts when start raises unexpected errors' do
+      allow(RailsCron).to receive(:start!).and_raise(StandardError, 'boom')
+
+      expect { task('rails_cron:start').invoke }.to raise_error(SystemExit)
+    end
+  end
+
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
- Introduced Rake tasks for managing RailsCron operations including tick, status, explain, and start.
- Updated Railtie to load these Rake tasks into Rails applications.
- Enhanced documentation to clarify that RailsCron does not auto-start by default and must be started explicitly.
- Added tests to ensure Rake tasks function correctly and handle errors appropriately.

closes: #10 